### PR TITLE
Update auto_joiner.py to add auto click on team tabs

### DIFF
--- a/auto_joiner.py
+++ b/auto_joiner.py
@@ -362,6 +362,11 @@ def main():
         if use_web_instead is not None:
             use_web_instead.click()
 
+        time.sleep(1)
+        teams_button= wait_until_found("[aria-label='Teams Toolbar']", 5)
+        if teams_button is not None:
+            teams_button.click()
+
         # if additional organisations are setup in the config file
     if 'organisation_num' in config and config['organisation_num'] > 1:
         additional_org_num = config['organisation_num']
@@ -377,6 +382,11 @@ def main():
                 use_web_instead = wait_until_found(".use-app-lnk", 5)
                 if use_web_instead is not None:
                     use_web_instead.click()
+
+                time.sleep(1)
+                teams_button= wait_until_found("[aria-label='Teams Toolbar']", 5)
+                if teams_button is not None:
+                    teams_button.click()
     
     print("Waiting for correct page...")
     if wait_until_found("div[data-tid='team-channel-list']", 60 * 5) is None:


### PR DESCRIPTION
With this if the user has some other tab by default the app will automatically find the teams tab and click on it.