### PR TITLE
Update auto_joiner.py

### DIFF
--- a/auto_joiner.py
+++ b/auto_joiner.py
@@ -370,12 +370,14 @@ def join_meeting(meeting):
     video_is_on = video_btn.get_attribute("aria-pressed")
     if video_is_on == "true":
         video_btn.click()
+        print("Video off")
 
     # turn mic off
     audio_btn = browser.find_element_by_css_selector("toggle-button[data-tid='toggle-mute']>div>button")
     audio_is_on = audio_btn.get_attribute("aria-pressed")
     if audio_is_on == "true":
         audio_btn.click()
+        print("Audio off")
 
     if 'random_delay' in config and config['random_delay']:
         delay = random.randrange(10, 31, 1)
@@ -401,6 +403,7 @@ def join_meeting(meeting):
     if 'auto_leave_after_min' in config and config['auto_leave_after_min'] > 0:
         hangup_thread = Timer(config['auto_leave_after_min'] * 60, hangup)
         hangup_thread.start()
+        print("Autoleave condition triggered")
 
 
 def get_meeting_members():
@@ -476,10 +479,12 @@ def main():
         login_pwd = wait_until_found("input[type='password']", 5)
         if login_pwd is not None:
             login_pwd.send_keys(Keys.ENTER)
-
+        
         keep_logged_in = wait_until_found("input[id='idBtn_Back']", 5)
         if keep_logged_in is not None:
             keep_logged_in.click()
+        else:
+            print("Login Unsuccessful, recheck entries in config.json")
 
         use_web_instead = wait_until_found(".use-app-lnk", 5, print_error=False)
         if use_web_instead is not None:
@@ -557,8 +562,9 @@ def main():
             if current_meeting is not None:
                 members = get_meeting_members()
 
-                if members <= 1:
+                if members <= 2:
                     hangup()
+                    print("Last attendee in meeting")
                     interval_count = 0
 
         interval_count += 1


### PR DESCRIPTION
**1. Added additional print statements that help the user understand what action was triggered/happened.** 
(In my case friend typed in the wrong password, he could not figure out what went wrong)
(Another friend (yes i have shared it a lot, great work) of mine had his video and audio turned on because he did not read the ReadMe completely and make changes in config.

2. In most cases, users do not host the meetings, it's usually an admin in the organization. Hence the leave_if_last condition will never be triggered because there will be 2 people in the meeting. Even if that's not the case, it will reduce bot like behaviour. Hence the **members <=2 change.**