### PR TITLE
Fatal error caused by a little bug

### DIFF
--- a/auto_joiner.py
+++ b/auto_joiner.py
@@ -522,7 +522,7 @@ def handle_leave_threshold(current_members, total_members):
     leave_number = config["leave_threshold_number"]
     leave_percentage = config["leave_threshold_percentage"]
 
-    if leave_number and leave_percentage == "":
+    if leave_number == "" and leave_percentage == "":
         if 0 < current_members < 3:
             print("Last attendee in meeting")
             hangup()


### PR DESCRIPTION
Leaving leave_number and leave_percentage as blanks results in this error 

File "auto_joiner.py", line 539, in handle_leave_threshold
    if 0 < float(leave_percentage) <= 150:
ValueError: could not convert string to float:

this will terminate the program.

 changing line 525 from this:
if leave_number and leave_percentage == "":

to this:
if leave_number == "" and leave_percentage == "":

fixed the problem for me